### PR TITLE
[리팩토링] 테스트코드 리팩토링

### DIFF
--- a/src/test/java/com/fastcampus/projectboard/service/ArticleServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboard/service/ArticleServiceTest.java
@@ -300,7 +300,7 @@ class ArticleServiceTest {
         then(hashtagService).shouldHaveNoInteractions();
     }
 
-    @DisplayName("게시글의 ID를 입력하면, 게시글을 삭제한다")
+    @DisplayName("게시글의 ID를 입력하면, 게시글을 삭제한다.")
     @Test
     void givenArticleId_whenDeletingArticle_thenDeletesArticle() {
         // Given
@@ -321,7 +321,7 @@ class ArticleServiceTest {
         then(hashtagService).should(times(2)).deleteHashtagWithoutArticles(any());
     }
 
-    @DisplayName("게시글 수를 조회하면, 게시글 수를 반환한다")
+    @DisplayName("게시글 수를 조회하면, 게시글 수를 반환한다.")
     @Test
     void givenNothing_whenCountingArticles_thenReturnsArticleCount() {
         // Given
@@ -336,7 +336,7 @@ class ArticleServiceTest {
         then(articleRepository).should().count();
     }
 
-    @DisplayName("해시태그를 조회하면, 유니크 해시태그 리스트를 반환한다")
+    @DisplayName("해시태그를 조회하면, 유니크 해시태그 리스트를 반환한다.")
     @Test
     void givenNothing_whenCalling_thenReturnsHashtags() {
         // Given


### PR DESCRIPTION
이 pr은 테스트코드의 품질을 관리하기 위해 일부 테스트 제목을 다른 테스트 제목과 일관된 형태로 수정한다.

This closes #93 