### PR TITLE
API 호출이 가능하도록 인증 설정 변경하기

### DIFF
--- a/src/main/java/com/fastcampus/projectboard/config/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/projectboard/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
         return http
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                        .mvcMatchers("/api/**").permitAll()
                         .mvcMatchers(
                                 HttpMethod.GET,
                                 "/",
@@ -48,6 +49,7 @@ public class SecurityConfig {
                                 .userService(oAuth2UserService)
                         )
                 )
+                .csrf(csrf -> csrf.ignoringAntMatchers("/api/**"))
                 .build();
     }
 


### PR DESCRIPTION
이 pr은 외부 서비스(강의에서는 어드민 서비스)에서 원활하게 게시판 서비스의 데이터 api를 이용할 수 있도록 시큐리티 설정을 업데이트 한다.

This closes #114 